### PR TITLE
Fix brace/newline handling: unify package imports to type_simulator.*…

### DIFF
--- a/src/type_simulator/text_typer/__main__.py
+++ b/src/type_simulator/text_typer/__main__.py
@@ -1,13 +1,13 @@
 import os
 import logging
 
-from src.type_simulator.text_typer.clipboard import (
+from type_simulator.text_typer.clipboard import (
     PyperclipClipboard,
     PlatformClipboard,
     TkClipboard,
 )
-from src.type_simulator.text_typer.parser import CommandParser
-from src.type_simulator.text_typer.token import Token
+from type_simulator.text_typer.parser import CommandParser
+from type_simulator.text_typer.token import Token
 
 logger = logging.getLogger(__name__)
 

--- a/src/type_simulator/text_typer/parser.py
+++ b/src/type_simulator/text_typer/parser.py
@@ -2,7 +2,7 @@ import re
 import logging
 from typing import List, Optional
 
-from src.type_simulator.text_typer.token import (
+from type_simulator.text_typer.token import (
     Token,
     TextToken,
     WaitToken,
@@ -65,7 +65,15 @@ class CommandParser:
                 if token:
                     tokens.append(token)
                 else:
-                    msg = f"Invalid sequence '{{{spec}}}'"
+                    # Escape control characters for clearer logging visibility
+                    def _escape(s: str) -> str:
+                        s = s.replace("\\", r"\\")
+                        s = s.replace("\n", r"\n").replace("\r", r"\r")
+                        return s
+                    preview = _escape(spec)
+                    if len(preview) > 200:
+                        preview = preview[:200] + "…"
+                    msg = f"Invalid sequence '{{{preview}}}'"
                     if self.strict:
                         logger.warning(msg)
                         # skip invalid spec in strict mode

--- a/src/type_simulator/type_simulator.py
+++ b/src/type_simulator/type_simulator.py
@@ -12,7 +12,7 @@ import pyautogui
 from type_simulator.editor_manager import EditorManager
 from type_simulator.file_manager import FileManager
 
-from src.type_simulator.text_typer.__main__ import TextTyper
+from type_simulator.text_typer.__main__ import TextTyper
 
 
 class Mode(Enum):


### PR DESCRIPTION
…, preserve empty lines, and improve escaped logging for invalid specs; add unit test